### PR TITLE
added support to create new directory

### DIFF
--- a/app/app/main.py
+++ b/app/app/main.py
@@ -87,17 +87,27 @@ async def results(filename: str):
 async def upload(
     request: fast.Request, 
     file: fast.UploadFile = fast.File(...),
-    user: mdl.User = fast.Depends(api_users.get_current_active_user)):
+    user: mdl.User = fast.Depends(api_users.get_current_active_user),
+    filedir:str = None):
 
     if not file.filename.endswith(VALID_EXTENSIONS):
         raise fast.HTTPException(
             status_code = 400,
             detail = 'File extension not allowed.')
-
-    dest = pathlib.Path('/'.join((
-        RESULTS_DIR,
+    
+    if filedir is not None:
+        NEW_DIR = '/'.join((RESULTS_DIR, filedir))
+        dest = pathlib.Path('/'.join((
+        NEW_DIR,
         pathlib.Path(file.filename).name
-    )))
+        )))
+        
+    else:
+        dest = pathlib.Path('/'.join((
+            RESULTS_DIR,
+            pathlib.Path(file.filename).name
+        )))
+
     dest.parent.mkdir(parents=True, exist_ok=True)
 
     async with aiofiles.open(dest, 'wb') as buffer:


### PR DESCRIPTION
At present all files from different sources are stored in a single directory. This makes difficult to differentiate between data and identify their source.
Added a support to send an extra argument as new directory in which we want to store the file.

Usecase - 
For storing prometheus data from CI pipelines, we can pass the UUID as the file directory name and all the data from this CI will be stored in that directory, hence makes easy to identify data in the future.