### PR TITLE
Updates for snappy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ WORKDIR ${APP_ROOT}
 RUN dnf install -y \
         gcc \
         libpq-devel \
-        python3.9-devel \
-    && dnf clean all \
+        python3.9-devel --nogpgcheck \
+    && dnf clean all --nogpgcheck \
     && pip install --requirement requirements.txt
 
 WORKDIR ${APP_ROOT}/app

--- a/README.md
+++ b/README.md
@@ -135,3 +135,17 @@ Username for the first super user.
 
 #### FIRST_SUPERUSER_PASSWORD
 Password for the first super user.
+
+---
+
+### Steps to create and run a new podman image of snappy server: 
+
+Make your changes in the snappy-data-server directory
+
+Run command : sudo podman build --tag name:tag -f ./Dockerfile
+This will create a local podman image 
+
+change the data_server_img var in podman-compose.sh file 
+eg : data_server_img="localhost/name:tag" 
+
+Run : ./podman-compose.sh (This will start the snappy server with any new local changes)

--- a/app/app/main.py
+++ b/app/app/main.py
@@ -25,7 +25,7 @@ HOST = env('DATA_SERVER_PUBLIC_HOST')
 PORT = env('DATA_SERVER_PORT') 
 VALID_EXTENSIONS = (
     '.png', '.jpeg', '.jpg',
-    '.tar.gz', '.tar.xz', '.tar.bz2', '.csv', '.txt', '.json', '.markdown', '.doc', '.docx', '.pdf', '.log', '.xml'
+    '.tar.gz', '.tar.xz', '.tar.bz2', '.csv', '.txt', '.json', '.markdown', '.doc', '.docx', '.pdf', '.log', '.xml', '.yml', '.yaml'
 )
 
 

--- a/app/app/main.py
+++ b/app/app/main.py
@@ -25,7 +25,7 @@ HOST = env('DATA_SERVER_PUBLIC_HOST')
 PORT = env('DATA_SERVER_PORT') 
 VALID_EXTENSIONS = (
     '.png', '.jpeg', '.jpg',
-    '.tar.gz', '.tar.xz', '.tar.bz2'
+    '.tar.gz', '.tar.xz', '.tar.bz2', '.csv', '.txt', '.json', '.markdown', '.doc', '.docx', '.pdf', '.log', '.xml'
 )
 
 

--- a/pod-compose.sh
+++ b/pod-compose.sh
@@ -37,6 +37,7 @@ podman run \
     --rm \
     $data_server_img ./scripts/prestart
 
+sleep 10s
 
 podman run \
     --detach \


### PR DESCRIPTION
### Fixes 
* added support for more required file extensions in snappy server
* added steps in readme to create and run a new podman image of snappy server:
* added --nogpgcheck flag during dnf install step in dockerfile since some  rpm's are unsigned or we don't have the signer's key
* inserted a sleep command in podman_compose.sh file so as to wait for the postgress db to initialize before starting the snappy server which attaches to the postgress service , without waiting , the snappy server container does not start and shows stopped state(this happens most of the times)
